### PR TITLE
use HTTP_EXPOSE etc for ports, fixes #1

### DIFF
--- a/docker-compose.meilisearch.yaml
+++ b/docker-compose.meilisearch.yaml
@@ -8,8 +8,11 @@ services:
     restart: "on-failure"
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-ddev}
-    ports:
-      - "7700:7700"
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=7699:7700
+      - HTTPS_EXPOSE=7700:7700
+    expose:
+      - "7700"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
@@ -22,17 +25,19 @@ services:
   web:
     links:
       - meilisearch:meilisearch
-  meilisearch_admin:
-    container_name: ddev-${DDEV_SITENAME}-meilisearch-admin
+  meilisearch-ui:
+    container_name: ddev-${DDEV_SITENAME}-meilisearch-ui
     image: riccoxie/meilisearch-ui:latest
     restart: always
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
-    ports:
-      - "8100:24900"
+    expose:
+      - "24900"
     environment:
-      - VIRTUAL_HOST=meilisearch.$DDEV_HOSTNAME
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=24899:24900
+      - HTTPS_EXPOSE=24900:24900
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
 volumes:


### PR DESCRIPTION
This gets you part of the way to where you're going.

* With this patch, you can use `https://<project>.ddev.site:7700` to access meilisearch, works fine in browser. (Not knowing anything about meilisearch, it makes me wonder why you want meilisearch-ui) Both http (on port 7699) and https are supported.
* Any code inside the web container can also access meilisearch at http://meilsearch:7700
* (perhaps overly opinionated) I changed the name of the meilisearch-ui container to `meilisearch-ui`
* meilisearch-ui is not yet working; it should work from the host at `https://<project>.ddev.site:24900`, but it fails. You can, however, `curl http://meilisearch-ui:24900` inside the web container. Have you used this before? The [docs](https://github.com/riccox/meilisearch-ui) surprisingly don't seem to hint on how you will tell meilisearch-ui where the meilisearch service is. We need to configure it to tell it that it's at the hostname `meilisearch` and port 7700 (probably default). But nothing I can see in the doc says anything about that. It also warns about CORS setup, but I'm sure you'll have to sort that out.


I removed the exotic `VIRTUAL_HOST=meilisearch.$DDEV_HOSTNAME` - try to get the simplest case working first. There's no need initially for a separate hostname.