### PR TITLE
Don't restart the service automatically after failure

### DIFF
--- a/docker-compose.meilisearch.yaml
+++ b/docker-compose.meilisearch.yaml
@@ -5,7 +5,7 @@ services:
     hostname: ${DDEV_SITENAME}-meilisearch
     image: getmeili/meilisearch:v1.9
     networks: [default, ddev_default]
-    restart: "on-failure"
+    restart: "no"
     expose:
       - "7700"
     environment:


### PR DESCRIPTION
I've noticed that the MeiliSearch container is restarted every time I reboot my computer, even when I don't start the project via ddev. This is inconsistent with the other services defined by ddev, which are only started on demand after a reboot. I think this is caused by `restart: on-failure`. Looks like rebooting the machine will kill the container immediately, resulting in a non-zero exit code.

Changing this to `restart: "no"` will fix this, and is the standard used for other ddev services.